### PR TITLE
Fix AppImage build and release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,20 @@ jobs:
     - name: Install dependencies
       run: |
         pacman -Syu --noconfirm
-        pacman -S --noconfirm base-devel python tk xorg-apps imagemagick wget git
+        pacman -S --noconfirm base-devel python tk xorg-apps imagemagick wget git fuse2
+        modprobe fuse
     - name: Build AppImage
       run: |
         chmod +x build_appimage.sh
         ./build_appimage.sh
+        # Ensure AppImage is properly created and has correct permissions
+        if [ ! -f "Linux_CRU-x86_64.AppImage" ]; then
+          echo "AppImage was not created successfully!"
+          exit 1
+        fi
+        chmod +x Linux_CRU-x86_64.AppImage
+        # Test that the AppImage is valid
+        ./Linux_CRU-x86_64.AppImage --appimage-extract &> /dev/null || exit 1
     - name: Generate new tag
       id: tag
       run: |
@@ -47,7 +56,8 @@ jobs:
         name: Release ${{ steps.tag.outputs.new_tag }}
         draft: false
         prerelease: false
-        files: Linux_CRU-x86_64.AppImage
+        files: |   # Using literal block scalar for better readability
+          Linux_CRU-x86_64.AppImage
         body: |
           Automated release for commit ${{ github.sha }}
           

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # build_appimage.sh - Main script to build the AppImage for Arch Linux
 
-# Ensure required packages are installed
-echo "Checking/installing required packages..."
-sudo pacman -S --needed python tk xorg-server-utils imagemagick
-
 # First check for the Python script
 echo "Checking for linux-cru.py..."
 if [ ! -f "linux-cru.py" ]; then
@@ -83,18 +79,14 @@ exec "${HERE}/usr/bin/linux_cru" "$@"
 EOF
 chmod +x linux_cru.AppDir/AppRun
 
-# Copy required system libraries with sudo
-echo "Copying system libraries..."
-sudo cp /usr/lib/libtk8.6.so linux_cru.AppDir/usr/lib/
-sudo cp /usr/lib/libtcl8.6.so linux_cru.AppDir/usr/lib/
-sudo cp -r /usr/lib/tk8.6 linux_cru.AppDir/usr/lib/
-sudo cp -r /usr/lib/tcl8.6 linux_cru.AppDir/usr/lib/
-sudo chown -R $USER:$USER linux_cru.AppDir/usr/lib/
+# Copy required system libraries
+cp /usr/lib/libtk8.6.so linux_cru.AppDir/usr/lib/
+cp /usr/lib/libtcl8.6.so linux_cru.AppDir/usr/lib/
+cp -r /usr/lib/tk8.6 linux_cru.AppDir/usr/lib/
+cp -r /usr/lib/tcl8.6 linux_cru.AppDir/usr/lib/
 
 # Copy Python standard library
-echo "Copying Python standard library..."
-sudo cp -r /usr/lib/python3.12/* linux_cru.AppDir/usr/lib/python3.12/
-sudo chown -R $USER:$USER linux_cru.AppDir/usr/lib/python3.12/
+cp -r /usr/lib/python3.12/* linux_cru.AppDir/usr/lib/python3.12/
 
 # Download appimagetool if not already present
 if [ ! -f "appimagetool-x86_64.AppImage" ]; then
@@ -105,6 +97,13 @@ fi
 
 # Build the AppImage
 echo "Building AppImage..."
+chmod +x linux_cru.AppDir/AppRun
 ARCH=x86_64 ./appimagetool-x86_64.AppImage linux_cru.AppDir Linux_CRU-x86_64.AppImage
 
+if [ ! -f "Linux_CRU-x86_64.AppImage" ]; then
+    echo "Error: AppImage creation failed!"
+    exit 1
+fi
+
+chmod +x Linux_CRU-x86_64.AppImage
 echo "AppImage created successfully: Linux_CRU-x86_64.AppImage"


### PR DESCRIPTION
This PR fixes issues with the AppImage build and release process:

1. Adds FUSE support to the container by:
   - Installing `fuse2` package
   - Loading the FUSE kernel module

2. Improves AppImage build reliability:
   - Removes unnecessary sudo commands (container runs as root)
   - Adds proper error checking
   - Fixes file permissions
   - Validates AppImage after creation

3. Fixes release process:
   - Improves file specification in release action
   - Ensures AppImage has correct permissions before release
   - Adds validation that AppImage exists and is valid

These changes should resolve the issues with AppImage creation failing and the release not finding the file.